### PR TITLE
Modernize typo

### DIFF
--- a/beacon.lua
+++ b/beacon.lua
@@ -8,6 +8,7 @@ minetest.register_node("ham_radio:beacon", {
     "ham_radio_transmitter_side.png",
     "ham_radio_beacon_front.png"
   },
+  use_textures_alpha = "clip",
   groups = {cracky=2,oddly_breakable_by_hand=2},
   sounds = default.node_sound_metal_defaults(),
   paramtype2 = "facedir",

--- a/beacon.lua
+++ b/beacon.lua
@@ -8,7 +8,7 @@ minetest.register_node("ham_radio:beacon", {
     "ham_radio_transmitter_side.png",
     "ham_radio_beacon_front.png"
   },
-  use_textures_alpha = "clip",
+  use_texture_alpha = "clip",
   groups = {cracky=2,oddly_breakable_by_hand=2},
   sounds = default.node_sound_metal_defaults(),
   paramtype2 = "facedir",

--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,0 @@
-default
-basic_materials?
-technic?
-digilines?

--- a/receiver_station.lua
+++ b/receiver_station.lua
@@ -17,6 +17,7 @@ minetest.register_node("ham_radio:receiver", {
     "ham_radio_receiver_side.png",
     "ham_radio_receiver_front.png"
   },
+  use_texture_alpha = "clip",
   groups = {cracky=2,oddly_breakable_by_hand=2},
   sounds = default.node_sound_metal_defaults(),
   paramtype2 = "facedir",


### PR DESCRIPTION
There was a typo in use_textures_alpha -> fixed to uses_texture_alpha.

It was already fixed before you merged but I wasn't on time to push it as I had to go to visit friends. Sorry.